### PR TITLE
[Spring Security] 4.2 스프링 시큐리티 구성하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/spring/springinaction/configuration/DataSourceConfig.java
+++ b/src/main/java/spring/springinaction/configuration/DataSourceConfig.java
@@ -1,0 +1,21 @@
+package spring.springinaction.configuration;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.security.core.userdetails.jdbc.JdbcDaoImpl;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class DataSourceConfig {
+
+    @Bean
+    DataSource dataSource() {
+        return new EmbeddedDatabaseBuilder()
+                .setType(EmbeddedDatabaseType.H2)
+                .addScript(JdbcDaoImpl.DEFAULT_USER_SCHEMA_DDL_LOCATION)
+                .build();
+    }
+}

--- a/src/main/java/spring/springinaction/security/SecurityConfig.java
+++ b/src/main/java/spring/springinaction/security/SecurityConfig.java
@@ -1,0 +1,44 @@
+package spring.springinaction.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/main").hasRole("USER")
+                        .requestMatchers("/", "/**").permitAll()
+                )
+                .httpBasic(Customizer.withDefaults());
+        return http.build();
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService() {
+        UserDetails user = User.builder()
+                .username("user")
+                .password(passwordEncoder().encode("password"))
+                .roles("USER")
+                .build();
+        return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+

--- a/src/main/java/spring/springinaction/security/SecurityConfig.java
+++ b/src/main/java/spring/springinaction/security/SecurityConfig.java
@@ -6,15 +6,9 @@ import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.provisioning.JdbcUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
-
-import javax.sql.DataSource;
 
 @Configuration
 public class SecurityConfig {
@@ -31,18 +25,6 @@ public class SecurityConfig {
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
                 .httpBasic(Customizer.withDefaults());
         return http.build();
-    }
-
-    @Bean
-    public UserDetailsService userDetailsService(DataSource dataSource) {
-        UserDetails user = User.builder()
-                .username("user")
-                .password(passwordEncoder().encode("password"))
-                .roles("USER")
-                .build();
-        JdbcUserDetailsManager userDetailsManager = new JdbcUserDetailsManager(dataSource);
-        userDetailsManager.createUser(user);
-        return userDetailsManager;
     }
 
     @Bean

--- a/src/main/java/spring/springinaction/security/UserRepositoryUserDetailsService.java
+++ b/src/main/java/spring/springinaction/security/UserRepositoryUserDetailsService.java
@@ -1,0 +1,21 @@
+package spring.springinaction.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import spring.springinaction.tacos.domain.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class UserRepositoryUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User '" + username + "' not found"));
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/model/User.java
+++ b/src/main/java/spring/springinaction/tacos/domain/model/User.java
@@ -1,0 +1,63 @@
+package spring.springinaction.tacos.domain.model;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.io.Serial;
+import java.util.Collection;
+import java.util.List;
+
+@Table(name = "users")
+@Entity
+@Data
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
+@RequiredArgsConstructor
+public class User implements UserDetails {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private final String username;
+    private final String password;
+    private final String fullName;
+    private final String street;
+    private final String city;
+    private final String state;
+    private final String zip;
+    private final String phoneNumber;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/repository/UserRepository.java
+++ b/src/main/java/spring/springinaction/tacos/domain/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package spring.springinaction.tacos.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import spring.springinaction.tacos.domain.model.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends CrudRepository<User, Long> {
+    Optional<User> findByUsername(String username);
+}

--- a/src/main/java/spring/springinaction/tacos/presentation/RegistrationController.java
+++ b/src/main/java/spring/springinaction/tacos/presentation/RegistrationController.java
@@ -1,0 +1,23 @@
+package spring.springinaction.tacos.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.bind.annotation.*;
+import spring.springinaction.tacos.domain.repository.UserRepository;
+import spring.springinaction.tacos.request.RegistrationRequest;
+
+@RestController
+@RequestMapping("/register")
+@RequiredArgsConstructor
+public class RegistrationController {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @PostMapping
+    public ResponseEntity<Void> processRegistration(@RequestBody RegistrationRequest request) {
+        userRepository.save(request.toUser(passwordEncoder));
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/request/RegistrationRequest.java
+++ b/src/main/java/spring/springinaction/tacos/request/RegistrationRequest.java
@@ -1,0 +1,19 @@
+package spring.springinaction.tacos.request;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import spring.springinaction.tacos.domain.model.User;
+
+public record RegistrationRequest(
+        String username,
+        String password,
+        String fullname,
+        String street,
+        String city,
+        String state,
+        String zip,
+        String phone
+) {
+    public User toUser(PasswordEncoder passwordEncoder) {
+        return new User(username, passwordEncoder.encode(password), fullname, street, city, state, zip, phone);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=spring-in-action

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driverClassName: org.h2.Driver
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+    hibernate:
+      ddl-auto: create


### PR DESCRIPTION
> 스프링 인 액션 : Java 8, Spring Boot 2.2.6 (Spring 5.2.x)
> 학습 환경 : Java 21, Spring Boot 3.3.9 (Spring 6.1.x)
> **Spring 6.x, Spring Boot 3.x 버전을 사용함으로써 책과 다른 점을 정리하는 것을 학습 목표로 삼는다.**

## 4.2 스프링 시큐리티 구성하기

스프링 시큐리티를 구성하기 위해 SecurityConfig 클래스를 생성한다.

### **SecurityConfig 클래스**

- 사용자의 HTTP 요청 경로에 대한 접근 제한과 같은 보안 관련 처리를 우리가 원하는 대로 커스텀 할 수 있다.
- 스프링 5 버전에서는 `WebSecurityConfigurerAdapter`를 상속하여 `configurer` 메소드를 override하여 사용한다.
- 스프링 6에서는 `WebSecurityConfigurerAdapter`이 deprecated(Spring 5.7.0) 되어 `SecurityFilterChain`를 Bean으로 만들어 사용하는 것을 권장한다.

참고 : https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter

### 사용자 스토어

**사용자 인증을 위해 사용자 정보를 저장하는 공간**을 **사용자 스토어**라고 한다.

Spring Security에서는 여러 가지의 사용자 스토어 구성 방법을 제공한다.

책에서는 `AuthenticationManagerBuilder`를 사용하여 사용자 스토어를 구현한다.

다만 docs에서는 UserDetailsService Bean에 `XXXUserDetailsManager` 구현체를 통해 구현한다.

- **메모리 기반 (In-Memory User Store) ([참고 docs](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/in-memory.html))**
    - `InMemoryUserDetailsManager` 를 사용
    - 애플리케이션 실행 중에만 유지됨 (재시작하면 데이터 사라짐)
    - 변경이 필요 없는 사용자의 경우 미리 내부에 정의하여 사용할 때 쓴다.
- **JDBC 기반 (Database User Store) ([참고 docs](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/jdbc.html))**
    - `JdbcUserDetailsManager`를 사용
    - 데이터베이스(H2, MySQL 등)에 사용자 정보 저장
    - `users`, `authorities` 테이블을 직접 사용 가능
    아래 코드와 같이 Spring Security에서 디폴트 스키마를 제공해준다.
        
        ```java
        @Bean
        DataSource dataSource() {
            return new EmbeddedDatabaseBuilder()
                    .setType(EmbeddedDatabaseType.H2)
                    .addScript(JdbcDaoImpl.DEFAULT_USER_SCHEMA_DDL_LOCATION)
                    .build();
        }
        ```
        
- **JPA 기반 (Custom Repository User Store) ([참고 docs](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/user-details-service.html))**
    - `UserDetailsService`를 구현하여 JPA 리포지토리 사용
    - `UserRepository` 등을 만들어 DB에서 사용자 정보 조회
    - 커스텀 엔티티와 필드 사용 가능

> 참고 1. 스프링 시큐리티 5 버전부터는 의무적으로 `PasswordEncoder`를 사용해서 비밀번호 암호화를 해야한다.
> 참고 2. 스프링 시큐리티에서 사용자 정보 인증 쿼리는 username, password, enabled 열의 값을 반환해야 한다.
> → UserDetails를 상속하면 몇몇의 메소드를 override 해야 하는데 이때 `getUsername`, `getPassword`, `isEnabled` 를 재정의하는 이유가 이때문이다.

### PasswordEncoder

```java
public interface PasswordEncoder {
    String encode(CharSequence rawPassword);

    boolean matches(CharSequence rawPassword, String encodedPassword);

    default boolean upgradeEncoding(String encodedPassword) {
        return false;
    }
}
```

암호화는 `encode`를 통해, db의 암호화된 비밀번호와 비교하는 작업은 `matches`메서드에서 수행되어야 한다.

### UserDetailsService

사용자가 로그인하면 Spring Security는 아래 작업을 수행한다.

- `loadUserByUsername(username)`을 호출해서 사용자 정보를 가져온다. (UserDetailsService에서 수행)
- 입력된 비밀번호와 저장된 비밀번호를 **`passwordEncoder.matches()`로 비교한다. (DaoAuthenticationProvider에서 수행)**
- 일치하면 로그인 성공, 틀리면 로그인 실패한다.

참고 : https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/dao-authentication-provider.html

## 새롭게 알게된 것

### Entity 직렬화 (Serializable)

```java
@Table(name = "users")
@Entity
@Data
@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true)
@RequiredArgsConstructor
public class User implements UserDetails {

    @Serial
    private static final long serialVersionUID = 1L;

```

책에서 위와 같이 serialVersionUID를 선언해뒀다.

```java
public interface UserDetails extends Serializable {
    Collection<? extends GrantedAuthority> getAuthorities();

    String getPassword();

    String getUsername();

    default boolean isAccountNonExpired() {
        return true;
    }

    default boolean isAccountNonLocked() {
        return true;
    }

    default boolean isCredentialsNonExpired() {
        return true;
    }

    default boolean isEnabled() {
        return true;
    }
}
```

알고 보니, UserDetails는 직렬화할 수 있는 인터페이스였다.

근데 직렬화를 왜 해야하는지 궁금했다.

찾아보니 김영한님의 말씀을 확인할 수 있었다.

![스크린샷 2025-03-22 오전 5 03 23](https://github.com/user-attachments/assets/e270effd-59f9-4977-9f06-d05192cdbf9c)

요약하자면, JPA 표준 스펙에 따르면, 엔티티에 `Serializable`을 적용하는 것이 맞지만, 실제로 엔티티를 직렬화하는 경우는 거의 없다.

예를 들어, 컨트롤러에서 엔티티를 직접 JSON으로 변환하여 반환하는 경우가 많을까?
대부분은 별도의 DTO를 만들어 변환한 후, DTO를 직렬화하여 응답하는 방식을 사용한다.
즉, 엔티티는 여러 곳에 직접 전송되지 않기 때문에 `Serializable`을 적용할 필요성이 크지 않다고 볼 수 있다.

개발 뉴비일 때, 양방향 연관관계를 맺은 엔티티를 바로 json으로 직렬화해서 반환하다가 양방향 순환참조 에러가 발생했었는데 이것도 결국은 엔티티를 response로 반환하려던게 문제이지 않았을까 싶다.