### PR TITLE
Chore: (#3) 프로젝트를 위한 기초 설정을 구축한다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,13 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/spring/springinaction/tacos/domain/model/Ingredient.java
+++ b/src/main/java/spring/springinaction/tacos/domain/model/Ingredient.java
@@ -1,0 +1,24 @@
+package spring.springinaction.tacos.domain.model;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@Data
+@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED, force = true)
+@Entity
+public class Ingredient {
+
+    @Id
+    private final String id;
+    private final String name;
+    private final Type type;
+
+    public enum Type {
+        WRAP, PROTEIN, VEGGIES, CHEESE, SAUCE,
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/model/Order.java
+++ b/src/main/java/spring/springinaction/tacos/domain/model/Order.java
@@ -1,0 +1,53 @@
+package spring.springinaction.tacos.domain.model;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Data
+@Entity
+@Table(name = "Taco_Order")
+public class Order implements Serializable {
+
+    @Serial
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private Date placedAt;
+
+    private String deliveryName;
+
+    private String deliveryStreet;
+
+    private String deliveryCity;
+
+    private String deliveryState;
+
+    private String deliveryZip;
+
+    private String ccNumber;
+
+    private String ccExpiration;
+
+    private String ccCVV;
+
+    @ManyToMany(targetEntity = Taco.class)
+    private List<Taco> tacos = new ArrayList<>();
+
+    public void addDesign(Taco design) {
+        this.tacos.add(design);
+    }
+
+    @PrePersist
+    void placedAt() {
+        this.placedAt = new Date();
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/model/Taco.java
+++ b/src/main/java/spring/springinaction/tacos/domain/model/Taco.java
@@ -1,0 +1,33 @@
+package spring.springinaction.tacos.domain.model;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+import java.util.Date;
+import java.util.List;
+
+@Data
+@Entity
+public class Taco {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    private Date createdAt;
+
+    @NotNull
+    @Size(min = 5, message = "이름은 최소 5글자 이상이어야 합니다.")
+    private String name;
+
+    @ManyToMany(targetEntity = Ingredient.class)
+    @Size(min = 1, message = "최소 1개 이상의 재료가 선택해야 합니다.")
+    private List<Ingredient> ingredients;
+
+    @PrePersist
+    void createdAt() {
+        this.createdAt = new Date();
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/repository/IngredientRepository.java
+++ b/src/main/java/spring/springinaction/tacos/domain/repository/IngredientRepository.java
@@ -1,0 +1,7 @@
+package spring.springinaction.tacos.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import spring.springinaction.tacos.domain.model.Ingredient;
+
+public interface IngredientRepository extends CrudRepository<Ingredient, String> {
+}

--- a/src/main/java/spring/springinaction/tacos/domain/repository/OrderRepository.java
+++ b/src/main/java/spring/springinaction/tacos/domain/repository/OrderRepository.java
@@ -1,0 +1,7 @@
+package spring.springinaction.tacos.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import spring.springinaction.tacos.domain.model.Order;
+
+public interface OrderRepository extends CrudRepository<Order, Long> {
+}

--- a/src/main/java/spring/springinaction/tacos/domain/repository/TacoRepository.java
+++ b/src/main/java/spring/springinaction/tacos/domain/repository/TacoRepository.java
@@ -1,0 +1,7 @@
+package spring.springinaction.tacos.domain.repository;
+
+import org.springframework.data.repository.CrudRepository;
+import spring.springinaction.tacos.domain.model.Taco;
+
+public interface TacoRepository extends CrudRepository<Taco, Long> {
+}

--- a/src/test/java/spring/springinaction/tacos/domain/repository/TacoRepositoryTest.java
+++ b/src/test/java/spring/springinaction/tacos/domain/repository/TacoRepositoryTest.java
@@ -1,0 +1,47 @@
+package spring.springinaction.tacos.domain.repository;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import spring.springinaction.tacos.domain.model.Ingredient;
+import spring.springinaction.tacos.domain.model.Taco;
+
+import java.util.List;
+
+@DataJpaTest
+class TacoRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private TacoRepository tacoRepository;
+
+    @Test
+    void PRIVATE_생성자에서_프록시객체가_생성된다() {
+        // 1. 재료 데이터 저장
+        Ingredient ingredient = new Ingredient("ING1", "Lettuce", Ingredient.Type.VEGGIES);
+        entityManager.persist(ingredient);
+
+        // 2. 타코 데이터 저장
+        Taco taco = new Taco();
+        taco.setName("Veggie Taco");
+        taco.setIngredients(List.of(ingredient));
+        entityManager.persist(taco);
+        entityManager.flush();
+        entityManager.clear();  // 1차 캐시 초기화 (프록시 확인)
+
+        // 3. Taco 조회 (Lazy 로딩 확인)
+        Taco foundTaco = tacoRepository.findById(taco.getId()).orElseThrow();
+        System.out.println(">>> Taco 조회 완료");
+
+        // 4. Ingredient 프록시 여부 확인
+        List<Ingredient> ingredients = foundTaco.getIngredients();
+        System.out.println(">>> ingredients 클래스: " + ingredients.getClass().getName());
+        System.out.println(">>> 첫 번째 ingredient 클래스: " + ingredients.get(0).getClass().getName());
+
+        // 5. 실제 필드 접근 (강제 초기화)
+        System.out.println(">>> 첫 번째 ingredient ID: " + ingredients.get(0).getId());
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:test
+    username: sa
+    password:
+    driverClassName: org.h2.Driver
+  jpa:
+    properties:
+      hibernate:
+        show_sql: true
+        format_sql: true
+    hibernate:
+      ddl-auto: create-drop


### PR DESCRIPTION
# 배운 점

1. `@OneToMany, @ManyToMany`에서 TargetEntity는 PRIVATE 기본 생성자를 가져도 된다.

![1](https://github.com/user-attachments/assets/fecb686b-fee6-443c-a3db-8c96aa0f0fee)
엔티티를 생성할 때 기본 생성자가 필요하다.

그래서 기본 생성자는 외부에 접근을 막기 위해 `PROTECTED` 로 설정한다. 연관관계에서 지연 로딩 사용 시, 프록시 객체가 만들어지는데 `PRIVATE`접근 제어자는 Hibernate에서 접근할 수 없어 프록시 객체가 만들어지지 않는다.

```java
@Data
@Entity
public class Taco {

    @Id
    @GeneratedValue(strategy = GenerationType.AUTO)
    private Long id;

    private Date createdAt;

    @NotNull
    @Size(min = 5, message = "이름은 최소 5글자 이상이어야 합니다.")
    private String name;

    @ManyToMany(targetEntity = Ingredient.class)
    @Size(min = 1, message = "최소 1개 이상의 재료가 선택해야 합니다.")
    private List<Ingredient> ingredients;

    @PrePersist
    void createdAt() {
        this.createdAt = new Date();
    }
}
```

```java
@Data
@NoArgsConstructor(access = AccessLevel.PRIVATE)
@Entity
public class Ingredient {

    @Id
    private String id;
    private String name;
    private Type type;

    public enum Type {
        WRAP, PROTEIN, VEGGIES, CHEESE, SAUCE,
    }
}

```

그럼 당연히 위 코드에서도 Ingredient가 PRIVATE 기본 생성자를 가지므로 프록시 관련 에러가 발생해야 한다.

![2](https://github.com/user-attachments/assets/acc1bb73-431b-4b48-bee4-641966e89bfc)
위 사진처럼 말이다.

그러나 테스트코드를 돌려보면?

```java
@DataJpaTest
class TacoRepositoryTest {

    @Autowired
    private TestEntityManager entityManager;

    @Autowired
    private TacoRepository tacoRepository;

    @Test
    void PRIVATE_생성자에서_프록시객체가_생성된다() {
        // 1. 재료 데이터 저장
        Ingredient ingredient = new Ingredient("ING1", "Lettuce", Ingredient.Type.VEGGIES);
        entityManager.persist(ingredient);

        // 2. 타코 데이터 저장
        Taco taco = new Taco();
        taco.setName("Veggie Taco");
        taco.setIngredients(List.of(ingredient));
        entityManager.persist(taco);
        entityManager.flush();
        entityManager.clear();  // 1차 캐시 초기화 (프록시 확인)

        // 3. Taco 조회 (Lazy 로딩 확인)
        Taco foundTaco = tacoRepository.findById(taco.getId()).orElseThrow();
        System.out.println(">>> Taco 조회 완료");

        // 4. Ingredient 프록시 여부 확인
        List<Ingredient> ingredients = foundTaco.getIngredients();
        System.out.println(">>> ingredients 클래스: " + ingredients.getClass().getName());
        System.out.println(">>> 첫 번째 ingredient 클래스: " + ingredients.get(0).getClass().getName());

        // 5. 실제 필드 접근 (강제 초기화)
        System.out.println(">>> 첫 번째 ingredient ID: " + ingredients.get(0).getId());
    }
}

```
![3](https://github.com/user-attachments/assets/f2a91b42-c949-4939-b225-e3673fc8420f)
???
IDE에서도 PROTECTED, PUBLIC으로 바꾸라고 하고, 프록시 객체는 PRIVATE에서 만들어지지 않는데 테스트가 성공한다.

### 이유

```sql
Hibernate: 
    select
        next value for taco_seq
Hibernate: 
    insert 
    into
        ingredient
        (name, type, id) 
    values
        (?, ?, ?)
Hibernate: 
    insert 
    into
        taco
        (created_at, name, id) 
    values
        (?, ?, ?)
Hibernate: 
    insert 
    into
        taco_ingredients
        (taco_id, ingredients_id) 
    values
        (?, ?)
Hibernate: 
    select
        t1_0.id,
        t1_0.created_at,
        t1_0.name 
    from
        taco t1_0 
    where
        t1_0.id=?
>>> Taco 조회 완료
>>> ingredients 클래스: org.hibernate.collection.spi.PersistentBag
Hibernate: 
    select
        i1_0.taco_id,
        i1_1.id,
        i1_1.name,
        i1_1.type 
    from
        taco_ingredients i1_0 
    join
        ingredient i1_1 
            on i1_1.id=i1_0.ingredients_id 
    where
        i1_0.taco_id=?
>>> 첫 번째 ingredient 클래스: spring.springinaction.tacos.domain.model.Ingredient
>>> 첫 번째 ingredient ID: ING1
```

위 쿼리는 테스트코드의 쿼리이다.

타코를 조회하면 ingredients는 지연 로딩으로 프록시 객체여야 한다.

그런데, 생소한 PersistentBag이 보인다.

```sql
>>> ingredients 클래스: org.hibernate.collection.spi.PersistentBag
```

- PersistentBag은 Hibernate가 엔티티의 컬렉션 필드를 관리하기 위해 제공하는 Collection Wrapper이다.
    - Entity가 영속화할 때 Entity 내 필드의 Collection을 추적하고 관리하기 위해 만들어진다.
    - 원본 Collection을 하이버네이트가 제공하는 내장 Collection(PersistentBag)으로 변경한다.

- PersistentBag
    - `ManyToOne`, `OneToOne` 관계에서는 프록시 객체가 생성되므로 기본 생성자가 필요하다.
    - `OneToMany`, `ManyToMany`는 프록시가 아닌 PersistentBag을 사용하므로 기본 생성자가 필요 없다.

```java
	public PersistentBag(SharedSessionContractImplementor session, Collection<E> coll) {
		super( session );
		providedCollection = coll;
		if ( coll instanceof List ) {
			bag = (List<E>) coll;
		}
		else {
			bag = new ArrayList<>( coll );
		}
		setInitialized();
		setDirectlyAccessible( true );
	}

```

추가로, 컬렉션 필드는 NPE를 방지하기 위해 직접 초기화하는 것이 좋다고 알고 있다.

더하여 하이버네이트는 컬렉션을 영속 상태로 만들 때 원본 컬렉션을 감싸고 있는 내장 컬렉션을 만들기 때문에 즉시 초기화 해서 사용하는 것을 권장한다고 한다!

---

2. enum은 static 제어자가 불필요하다.

![4](https://github.com/user-attachments/assets/0270a030-74c8-424e-afae-2c0a7a5b3f3d)
책에서는 static을 사용하지만, 이는 불필요한 코드이다.

Java에서 `enum`은 클래스 내부에서 선언되든, 독립적으로 선언되든 자동으로 `static` 이기 때문이다.

---

3. JpaRepository VS CrudRepository

![crudvsjpadrawio](https://github.com/user-attachments/assets/41e19512-cb62-438d-b59d-73955a5e6a5e)
- CrudRepository : 주로 CRUD 기능을 제공한다.
- JpaRepository : JPA(Java Persistence API) 전용 Repository 확장 인터페이스.
    - CrudRepository, PagingAndSortingRepository의 기능을 포함한다.
    - CRUD + 페이징 및 정렬 기능


#### 참고
- https://jaeseo0519.tistory.com/252
- **자바 ORM 표준 JPA 프로그래밍**
- https://www.geeksforgeeks.org/spring-boot-difference-between-crudrepository-and-jparepository/