### PR TITLE
[Spring Security] 4.4 사용자 인지하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'com.auth0:java-jwt:4.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/spring/springinaction/security/SecurityConfig.java
+++ b/src/main/java/spring/springinaction/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package spring.springinaction.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -9,9 +10,14 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import spring.springinaction.security.filter.JwtAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -23,7 +29,8 @@ public class SecurityConfig {
                 // h2 console 접속을 위한 하위 2가지 조건 추가
                 .csrf(AbstractHttpConfigurer::disable)
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
-                .httpBasic(Customizer.withDefaults());
+                .httpBasic(Customizer.withDefaults())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/spring/springinaction/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/spring/springinaction/security/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package spring.springinaction.security.filter;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import spring.springinaction.tacos.domain.model.User;
+import spring.springinaction.tacos.domain.repository.UserRepository;
+import spring.springinaction.utils.JwtUtils;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final UserRepository userRepository;
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (token != null) {
+            try {
+                DecodedJWT decodedJWT = jwtUtils.verify(token);
+                Long userId = Long.parseLong(decodedJWT.getClaim("userId").asString());
+                User user = userRepository.findById(userId).orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception e) {
+                response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid or expired JWT token");
+                return;
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/domain/model/Order.java
+++ b/src/main/java/spring/springinaction/tacos/domain/model/Order.java
@@ -23,6 +23,9 @@ public class Order implements Serializable {
 
     private Date placedAt;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
     private String deliveryName;
 
     private String deliveryStreet;

--- a/src/main/java/spring/springinaction/tacos/presentation/OrderController.java
+++ b/src/main/java/spring/springinaction/tacos/presentation/OrderController.java
@@ -1,0 +1,34 @@
+package spring.springinaction.tacos.presentation;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.springinaction.tacos.domain.model.Order;
+import spring.springinaction.tacos.domain.model.User;
+import spring.springinaction.tacos.domain.repository.OrderRepository;
+import spring.springinaction.tacos.request.ProcessOrderRequest;
+
+@RestController
+@RequestMapping("/orders")
+@RequiredArgsConstructor
+@Slf4j
+public class OrderController {
+
+    private final OrderRepository orderRepository;
+
+    @PostMapping
+    public ResponseEntity<Void> processOrder(@RequestBody ProcessOrderRequest request, @AuthenticationPrincipal User user) {
+        log.info("Processing order request : {}", request);
+        log.info("User : {}", user);
+
+        Order order = request.toOrder();
+        order.setUser(user);
+        orderRepository.save(order);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/spring/springinaction/tacos/presentation/RegistrationController.java
+++ b/src/main/java/spring/springinaction/tacos/presentation/RegistrationController.java
@@ -3,9 +3,17 @@ package spring.springinaction.tacos.presentation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import spring.springinaction.tacos.domain.model.User;
 import spring.springinaction.tacos.domain.repository.UserRepository;
 import spring.springinaction.tacos.request.RegistrationRequest;
+import spring.springinaction.utils.JwtUtils;
+import spring.springinaction.utils.JwtUtils.Payload;
+
+import java.util.Set;
 
 @RestController
 @RequestMapping("/register")
@@ -14,10 +22,17 @@ public class RegistrationController {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final JwtUtils jwtUtils;
 
     @PostMapping
-    public ResponseEntity<Void> processRegistration(@RequestBody RegistrationRequest request) {
-        userRepository.save(request.toUser(passwordEncoder));
-        return ResponseEntity.ok().build();
+    public ResponseEntity<String> processRegistration(@RequestBody RegistrationRequest request) {
+        User user = userRepository.save(request.toUser(passwordEncoder));
+
+        Set<Payload> payloads = Set.of(
+                new Payload("userId", user.getId().toString()),
+                new Payload("username", user.getUsername())
+        );
+        String accessToken = jwtUtils.createAccessToken(payloads);
+        return ResponseEntity.ok(accessToken);
     }
 }

--- a/src/main/java/spring/springinaction/tacos/request/ProcessOrderRequest.java
+++ b/src/main/java/spring/springinaction/tacos/request/ProcessOrderRequest.java
@@ -1,0 +1,27 @@
+package spring.springinaction.tacos.request;
+
+import spring.springinaction.tacos.domain.model.Order;
+
+public record ProcessOrderRequest(
+        String deliveryName,
+        String deliveryStreet,
+        String deliveryCity,
+        String deliveryState,
+        String deliveryZip,
+        String ccNumber,
+        String ccExpiration,
+        String ccCVV
+) {
+    public Order toOrder() {
+        Order order = new Order();
+        order.setDeliveryName(deliveryName);
+        order.setDeliveryStreet(deliveryStreet);
+        order.setDeliveryCity(deliveryCity);
+        order.setDeliveryState(deliveryState);
+        order.setDeliveryZip(deliveryZip);
+        order.setCcNumber(ccNumber);
+        order.setCcExpiration(ccExpiration);
+        order.setCcCVV(ccCVV);
+        return order;
+    }
+}

--- a/src/main/java/spring/springinaction/utils/JwtUtils.java
+++ b/src/main/java/spring/springinaction/utils/JwtUtils.java
@@ -1,0 +1,73 @@
+package spring.springinaction.utils;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtUtils {
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.accessTokenExpirySeconds}")
+    private Long accessTokenExpirySeconds;
+
+    public String createAccessToken(Set<Payload> payloads) {
+        Map<String, String> payloadMap = new HashMap<>();
+        payloads.forEach(payload -> payloadMap.put(payload.key, payload.value));
+        return createJwt(payloadMap);
+    }
+
+    public DecodedJWT verify(String jwt) {
+        Algorithm algorithm = getAlgorithm();
+        JWTVerifier verifier = getVerifier(algorithm);
+
+        try {
+            return verifier.verify(jwt);
+        } catch (Exception e){
+            throw new JWTVerificationException("JWT verification failed", e);
+        }
+    }
+
+    private JWTVerifier getVerifier(Algorithm algorithm) {
+        return JWT.require(algorithm)
+                .withIssuer(issuer)
+                .build();
+    }
+
+    private String createJwt(Map<String, String> payload) {
+        Algorithm algorithm = getAlgorithm();
+        Instant expiresAt = Instant.now().plusSeconds(accessTokenExpirySeconds);
+
+        return JWT.create()
+                .withIssuer(issuer)
+                .withPayload(payload)
+                .withExpiresAt(expiresAt)
+                .sign(algorithm);
+    }
+
+    private Algorithm getAlgorithm() {
+        return Algorithm.HMAC256(secret);
+    }
+
+    public record Payload (
+            String key,
+            String value
+    ){
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -16,3 +16,8 @@ spring:
         format_sql: true
     hibernate:
       ddl-auto: create
+
+jwt:
+  issuer: test-issuer
+  secret: test-secret
+  accessTokenExpirySeconds: 60

--- a/src/test/java/spring/springinaction/utils/JwtUtilsTest.java
+++ b/src/test/java/spring/springinaction/utils/JwtUtilsTest.java
@@ -1,0 +1,60 @@
+package spring.springinaction.utils;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import spring.springinaction.utils.JwtUtils.Payload;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JwtUtilsTest {
+
+    private JwtUtils jwtUtils;
+
+    @BeforeEach
+    void setUp() {
+        jwtUtils = new JwtUtils();
+
+        ReflectionTestUtils.setField(jwtUtils, "issuer", "test-issuer");
+        ReflectionTestUtils.setField(jwtUtils, "secret", "test-secret");
+        ReflectionTestUtils.setField(jwtUtils, "accessTokenExpirySeconds", 60L);
+    }
+
+    @Test
+    void createAccessToken_ShouldReturnValidToken() {
+        // Given
+        Set<Payload> payloads = Set.of(
+                new Payload("userId", "12345"),
+                new Payload("role", "USER")
+        );
+
+        // When
+        String token = jwtUtils.createAccessToken(payloads);
+
+        // Then
+        System.out.println("token: " + token);
+        assertThat(token).isNotNull().isNotBlank();
+    }
+
+    @Test
+    void verify_ShouldReturnDecodedJWT_WhenTokenIsValid() {
+        // Given
+        Set<Payload> payloads = Set.of(
+                new Payload("userId", "12345"),
+                new Payload("role", "USER")
+        );
+        String token = jwtUtils.createAccessToken(payloads);
+
+        // When
+        DecodedJWT decodedJWT = jwtUtils.verify(token);
+
+        // Then
+        assertThat(decodedJWT).isNotNull();
+        assertThat(decodedJWT.getIssuer()).isEqualTo("test-issuer");
+        assertThat(decodedJWT.getClaim("userId").asString()).isEqualTo("12345");
+        assertThat(decodedJWT.getClaim("role").asString()).isEqualTo("USER");
+    }
+}


### PR DESCRIPTION
> `4.3 웹 요청 보안 처리하기`는 앞선 내용과 반복되는 내용이라, 새로운 내용인 SpEL(Spring Expression Language)를 작성하고 코드는 작성하지 않습니다.

## SpEL (Spring Expression Language)
스프링 시큐리티에서 제공하는 메서드는 요청 처리의 기본적인 보안 규칙을 제공한다. 그러나 각 메서드에 정의된 보안 규칙만 사용해야 한다.
```java
@Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .authorizeHttpRequests((auth) -> auth
                        .requestMatchers("/main").hasRole("USER")
                        .requestMatchers("/", "/**").permitAll()
                )
```

위 문제의 대안으로 `access()` 메서드를 사용하면 더욱 풍푸하게 보안 규칙을 선언할 수 있다. 이때 필요한게 SpEL이다.
```java
    @Bean
    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .authorizeHttpRequests((auth) -> auth
                        .requestMatchers("/profile").access(new WebExpressionAuthorizationManager("#principal.username == 'john_doe'")) // 이와 같이 사용한다.
                        .requestMatchers("/", "/**").permitAll()
                )
```
이처럼 스프링 시큐리티에서 확장된 SpEL을 사용하면 되고, 더 여러개 추가할 수도 있다.
```java
.requestMatchers("/admin").access("hasRole('ADMIN') or hasRole('MANAGER')")
```

아래 사진 2장은 스프링 시큐리티에서 제공하는 SpEL이다.
![스크린샷 2025-03-23 오후 10 11 24](https://github.com/user-attachments/assets/86824b05-25c6-44fc-8ee8-0228a2c5d7df)
![스크린샷 2025-03-23 오후 10 11 38](https://github.com/user-attachments/assets/da6a5dd0-3a1f-4e21-8371-18133c2297dd)
---
# 4.4 사용자 인지하기
## 인증된 사용자를 인지하는 방법
### 1.`Principal` 객체를 컨트롤러 메서드에 주입한다.
**Principal**
- 현재 인증된 사용자 (UserDetails)를 직접 참조한다.
- Principal에는 사용자의 주요 정보 (username, ID 등)만 포함한다.
- 내부적으로 Authentication.getPrincipal() 값을 의미한다.
![스크린샷 2025-03-23 오후 11 02 53](https://github.com/user-attachments/assets/9dd82776-6077-4b00-bcab-d5212fc838b4)

### 2.`Authentication` 객체를 컨트롤러 메서드에 주입한다.
**Authentication**
- Authentication은 인증된 사용자 정보(Principal) + 인증 관련 추가 정보를 포함한다.
- SecurityContext(인증 정보를 저장하는 컨텍스트)에 저장된 전체 인증 정보를 제공한다.

### 3.`SecurityContextHolder`를 사용해서 보안 컨텍스트를 얻는다.
**SecurityContextHolder**
- 현재 인증된 사용자 정보를 저장하는 공간이다.
- SecurityContext 객체를 관리한다.
- SecurityContextHolder.getContext()를 통해 현재 사용자의 인증 정보를 가져올 수 있다.

### 4.`@AuthenticationPrincipal` 애노테이션을 메서드에 지정한다.
**@AuthenticationPrincipal**
```java
/**
 * Annotation that is used to resolve `Authentication.getPrincipal()` to a method
 * argument.
 *
 * @author Rob Winch
 * @since 4.0
 *
 * See: <a href=
 * "{@docRoot}/org/springframework/security/web/method/annotation/AuthenticationPrincipalArgumentResolver.html" >
 * AuthenticationPrincipalArgumentResolver </a>
 */
@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
@Retention(RetentionPolicy.RUNTIME)
@Documented
public @interface AuthenticationPrincipal {
```
즉 Authentication 객체에서 사용자 정보(Principal)을 가져오는 애노테이션이다.

### 요약
- 인증된 사용자에 관한 정보는 SecurityContext 객체(`SecurityContextHolder.getContext()`)를 통해서 얻거나, `@AutnehticationPrincipal`을 사용해서 컨트롤러에 주입한다.

**참고**
- https://docs.spring.io/spring-security/reference/servlet/authentication/architecture.html#servlet-authentication-securitycontextholder
- https://docs.spring.io/spring-security/reference/5.8/servlet/authorization/expression-based.html
